### PR TITLE
Jupyter notebook for win probe data and more refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+CardiacUltrasoundPhaseEstimation
+=================================
+
+This repository contains an image-based method for cardio-respiratory phase
+estimation, gating, and temporal super-resolution of cardiac ultrasound.
+
+The core algorithm is implemented in the class [uspgs.USPGS](https://github.com/KitwareMedical/CardiacUltrasoundPhaseEstimation/blob/master/uspgs.py#L22). 
+Please see the docstrings to understand its functionality.
+
+There are two jupyter notebooks that will further help understand how to use the method:
+* [MICCAI_2017_experiments.ipynb](https://github.com/KitwareMedical/CardiacUltrasoundPhaseEstimation/blob/master/MICCAI_2017_experiments.ipynb) - contains the code used to generate the results for the MICCAI submission.
+* [WinProbe-Experiments.ipynb](https://github.com/KitwareMedical/CardiacUltrasoundPhaseEstimation/blob/master/WinProbe-Experiments.ipynb) - shows how to apply the algorithm on WinProbe data.
+
+Prerequisites
+-------------
+
+The following python packages need to be installed in your virtual environment 
+to be able to run the code: 
+
+* numpy
+* scipy
+* scikit-learn
+* statsmodels
+* matplotlib
+* jupyter
+* angles
+* SimpleITK
+* MedPy
+* opencv-python
+
+You can run the following command to install these dependencies:
+
+```
+pip install requirements.txt
+```
+
+The code uses opencv's Python interface for reading, displaying, and writing videos. 
+
+pip installing the requirements using the aforementioned command attempts to 
+install opencv's python interface by installing the `opencv-python>=3.2.07` 
+package from [PyPI](https://pypi.python.org/pypi/opencv-python) for convenience. 
+
+However since this is not an official release of opencv, it may cause issues,
+especially on OSX and Linux platforms. If this happens, download and install 
+opencv binaries for your operating system from the official opencv website
+ [here](http://opencv.org/releases.html). 
+

--- a/utils.py
+++ b/utils.py
@@ -163,31 +163,31 @@ def loadVideoFromFile(dataFilePath, sigmaSmooth=None, resizeAmount=None):
     # print metadata
     metadata = {}
 
-    numFrames = vidseq.get(cv2.cv.CV_CAP_PROP_FRAME_COUNT)
+    numFrames = vidseq.get(cv2.CAP_PROP_FRAME_COUNT)
     print '\tFRAME_COUNT = ', numFrames
     metadata['FRAME_COUNT'] = numFrames
 
-    frameHeight = vidseq.get(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT)
+    frameHeight = vidseq.get(cv2.CAP_PROP_FRAME_HEIGHT)
     if frameHeight > 0:
         print '\tFRAME HEIGHT = ', frameHeight
         metadata['FRAME_HEIGHT'] = frameHeight
 
-    frameWidth = vidseq.get(cv2.cv.CV_CAP_PROP_FRAME_WIDTH)
+    frameWidth = vidseq.get(cv2.CAP_PROP_FRAME_WIDTH)
     if frameWidth > 0:
         print '\tFRAME WIDTH = ', frameWidth
         metadata['FRAME_WIDTH'] = frameWidth
 
-    fps = vidseq.get(cv2.cv.CV_CAP_PROP_FPS)
+    fps = vidseq.get(cv2.CAP_PROP_FPS)
     if fps > 0:
         print '\tFPS = ', fps
         metadata['FPS'] = fps
 
-    fmt = vidseq.get(cv2.cv.CV_CAP_PROP_FORMAT)
+    fmt = vidseq.get(cv2.CAP_PROP_FORMAT)
     if fmt > 0:
         print '\FORMAT = ', fmt
         metadata['FORMAT'] = fmt
 
-    vmode = vidseq.get(cv2.cv.CV_CAP_PROP_MODE)
+    vmode = vidseq.get(cv2.CAP_PROP_MODE)
     if vmode > 0:
         print '\MODE = ', vmode
         metadata['MODE'] = MODE


### PR DESCRIPTION
This PR adds:
* Adds a brief README on how to understand and use the code in this repository.
* A jupyter notebook demonstrating how to apply the algorithm on WinProbe data. If the video does not contain any motions other than cardiac and respiratory motion then the algorithm works well. I am still in the process of fully evaluating the band pass idea to suppress non cardio-respiratory motions from the frame similarity signal.
* Adds code to the optionally apply a band-pass filter to the frame similarity signal before decomposing it into cardiac and respiratory components. While this does suppress the motions mostly there are some unwanted edge effects between different blocks of motions that i am trying to resolve.

