### PR TITLE
Changed bandpass filter to zero-phase implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ to be able to run the code:
 You can run the following command to install these dependencies:
 
 ```
-pip install requirements.txt
+pip install -U -r requirements.txt
 ```
 
 The code uses opencv's Python interface for reading, displaying, and writing videos. 
 
 pip installing the requirements using the aforementioned command attempts to 
-install opencv's python interface by installing the `opencv-python>=3.2.07` 
+install opencv's python interface by installing the `opencv-python>=3.2.0.7` 
 package from [PyPI](https://pypi.python.org/pypi/opencv-python) for convenience. 
 
 However since this is not an official release of opencv, it may cause issues,
 especially on OSX and Linux platforms. If this happens, download and install 
-opencv binaries for your operating system from the official opencv website
- [here](http://opencv.org/releases.html). 
+opencv binaries for your operating system from the official opencv website.
+Follow the instructions [here](http://docs.opencv.org/3.2.0/da/df6/tutorial_py_table_of_contents_setup.html) to install OpenCV-Python on your operating system. 
 

--- a/uspgs.py
+++ b/uspgs.py
@@ -873,7 +873,7 @@ class USPGS(object):
                 pass_band = np.array(self.band_pass_bpm) / 60.0
                 nyq = 0.5 * self.fps_
                 b, a = scipy.signal.butter(5, pass_band / nyq, btype='band')
-                ts_bpass = scipy.signal.lfilter(b, a, ts)
+                ts_bpass = scipy.signal.filtfilt(b, a, ts)
 
             else:
 


### PR DESCRIPTION
Bandpass filter was implemented with lfilter() which does not preserve phase. This was changed to a zero-phase filter implementation using filtfilt() command.  

Using lfilter:
![image](https://cloud.githubusercontent.com/assets/5804398/26126350/4586726e-3a53-11e7-8bb2-ab93794241a1.png)

Using filtfilt:
![image](https://cloud.githubusercontent.com/assets/5804398/26126383/5b0b8e3a-3a53-11e7-8c9a-4ef7531fe107.png)
